### PR TITLE
refactor: change namespace to as per PSR-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Add the service provider to your `config/app.php`:
 ```php
 'providers' => [
     // ...
-    haiderjabbar\laravelsolr\LaravelSolrServiceProvider::class,
+    HaiderJabbar\LaravelSolr\LaravelSolrServiceProvider::class,
 ];
 ```
 
 You should publish the config/solr.php config file with:
 
 ```bash
-php artisan vendor:publish --provider="haiderjabbar\laravelsolr\LaravelSolrServiceProvider"
+php artisan vendor:publish --provider="HaiderJabbar\LaravelSolr\LaravelSolrServiceProvider"
 ```
 
 ## Available Commands
@@ -64,7 +64,7 @@ php artisan solr:delete-fields
 ### Adding Documents
 
 ```php
-use haiderjabbar\laravelsolr\Models\SolrModel;
+use HaiderJabbar\LaravelSolr\Models\SolrModel;
 
 $coreName = 'your_core_name';
 $data = [
@@ -98,9 +98,9 @@ $result = SolrModel::addChildToParent($coreName, $parentId, "child", $childData)
 ### Controller Example
 
 ```php
-use haiderjabbar\laravelsolr\Services\SolrQueryBuilder;
+use HaiderJabbar\LaravelSolr\Services\SolrQueryBuilder;
 use Illuminate\Http\Request;
-use haiderjabbar\laravelsolr\Models\SolrModel;
+use HaiderJabbar\LaravelSolr\Models\SolrModel;
 
 
 class SolrController extends Controller
@@ -142,7 +142,7 @@ laravelsolr provides a powerful and fluent interface for building Solr queries t
 ### Basic Usage
 
 ```php
-use haiderjabbar\laravelsolr\Services\SolrQueryBuilder;
+use HaiderJabbar\LaravelSolr\Services\SolrQueryBuilder;
 
 $builder = new SolrQueryBuilder($coreName);
 ```

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "haiderjabbar\\laravelsolr\\": "src/"
+            "HaiderJabbar\\LaravelSolr\\": "src/"
         }
     },
     "scripts": {
@@ -54,7 +54,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "haiderjabbar\\laravelsolr\\LaravelSolrServiceProvider"
+                "HaiderJabbar\\LaravelSolr\\LaravelSolrServiceProvider"
             ]
         }
     }

--- a/src/Console/Commands/CreateSolrCore.php
+++ b/src/Console/Commands/CreateSolrCore.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -33,7 +33,7 @@ class CreateSolrCore extends Command
 <?php
 
 use Illuminate\\Database\\Migrations\\Migration;
-use haiderjabbar\\laravelsolr\\Services\\CoreSolrService;
+use HaiderJabbar\\LaravelSolr\\Services\\CoreSolrService;
 
 return new class extends Migration
 {

--- a/src/Console/Commands/CreateSolrFields.php
+++ b/src/Console/Commands/CreateSolrFields.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use haiderjabbar\laravelsolr\Schema\SolrSchemaBuilder;
+use HaiderJabbar\LaravelSolr\Schema\SolrSchemaBuilder;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class CreateSolrFields extends Command
@@ -66,10 +66,10 @@ class CreateSolrFields extends Command
 <?php
 
 use Illuminate\\Database\\Migrations\\Migration;
-use haiderjabbar\\laravelsolr\\Services\\FieldsSolrService;
-use haiderjabbar\\laravelsolr\\Schema\\SolrSchemaBuilder;
-use haiderjabbar\laravelsolr\Services\CoreSolrService;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use HaiderJabbar\\LaravelSolr\\Services\\FieldsSolrService;
+use HaiderJabbar\\LaravelSolr\\Schema\\SolrSchemaBuilder;
+use HaiderJabbar\\LaravelSolr\\Services\\CoreSolrService;
+use Symfony\\Component\\Console\\Output\\ConsoleOutput;
 return new class extends Migration
 {
     protected \$FieldsSolrService;

--- a/src/Console/Commands/DeleteSolrCore.php
+++ b/src/Console/Commands/DeleteSolrCore.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -33,7 +33,7 @@ class DeleteSolrCore extends Command
 <?php
 
 use Illuminate\\Database\\Migrations\\Migration;
-use haiderjabbar\\laravelsolr\\Services\\CoreSolrService;
+use HaiderJabbar\\LaravelSolr\\Services\\CoreSolrService;
 
   return new class extends Migration
 {

--- a/src/Console/Commands/DeleteSolrFields.php
+++ b/src/Console/Commands/DeleteSolrFields.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use haiderjabbar\laravelsolr\Schema\SolrSchemaBuilder;
+use HaiderJabbar\LaravelSolr\Schema\SolrSchemaBuilder;
 
 class DeleteSolrFields extends Command
 {
@@ -49,7 +49,7 @@ class DeleteSolrFields extends Command
 <?php
 
 use Illuminate\\Database\\Migrations\\Migration;
-use haiderjabbar\\laravelsolr\\Services\\FieldsSolrService;
+use HaiderJabbar\\LaravelSolr\\Services\\FieldsSolrService;
 
 return new class extends Migration
 {

--- a/src/Console/Commands/UpdateSolrCore.php
+++ b/src/Console/Commands/UpdateSolrCore.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -38,7 +38,7 @@ class UpdateSolrCore extends Command
 <?php
 
 use Illuminate\\Database\\Migrations\\Migration;
-use haiderjabbar\\laravelsolr\\Services\\CoreSolrService;
+use HaiderJabbar\\LaravelSolr\\Services\\CoreSolrService;
 
 return new class extends Migration
 {

--- a/src/Console/Commands/UpdateSolrFields.php
+++ b/src/Console/Commands/UpdateSolrFields.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use haiderjabbar\laravelsolr\Schema\SolrSchemaBuilder;
+use HaiderJabbar\LaravelSolr\Schema\SolrSchemaBuilder;
 
 class UpdateSolrFields extends Command
 {
@@ -69,9 +69,9 @@ class UpdateSolrFields extends Command
 <?php
 
 use Illuminate\\Database\\Migrations\\Migration;
-use haiderjabbar\\laravelsolr\\Services\\FieldsSolrService;
-use haiderjabbar\\laravelsolr\\Schema\\SolrSchemaBuilder;
-use haiderjabbar\\laravelsolr\\Services\\CoreSolrService;
+use HaiderJabbar\\LaravelSolr\\Services\\FieldsSolrService;
+use HaiderJabbar\\LaravelSolr\\Schema\\SolrSchemaBuilder;
+use HaiderJabbar\\LaravelSolr\\Services\\CoreSolrService;
 
 return new class extends Migration
 {

--- a/src/LaravelSolr.php
+++ b/src/LaravelSolr.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr;
+namespace HaiderJabbar\LaravelSolr;
 
 class laravelsolr
 {

--- a/src/LaravelSolrServiceProvider.php
+++ b/src/LaravelSolrServiceProvider.php
@@ -1,12 +1,12 @@
 <?php
-namespace haiderjabbar\laravelsolr;
+namespace HaiderJabbar\LaravelSolr;
 
-use haiderjabbar\laravelsolr\Console\Commands\CreateSolrFields;
-use haiderjabbar\laravelsolr\Console\Commands\CreateSolrCore;
-use haiderjabbar\laravelsolr\Console\Commands\DeleteSolrCore;
-use haiderjabbar\laravelsolr\Console\Commands\DeleteSolrFields;
-use haiderjabbar\laravelsolr\Console\Commands\UpdateSolrCore;
-use haiderjabbar\laravelsolr\Console\Commands\UpdateSolrFields;
+use HaiderJabbar\LaravelSolr\Console\Commands\CreateSolrFields;
+use HaiderJabbar\LaravelSolr\Console\Commands\CreateSolrCore;
+use HaiderJabbar\LaravelSolr\Console\Commands\DeleteSolrCore;
+use HaiderJabbar\LaravelSolr\Console\Commands\DeleteSolrFields;
+use HaiderJabbar\LaravelSolr\Console\Commands\UpdateSolrCore;
+use HaiderJabbar\LaravelSolr\Console\Commands\UpdateSolrFields;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelSolrServiceProvider extends ServiceProvider

--- a/src/Models/SolrModel.php
+++ b/src/Models/SolrModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Models;
+namespace HaiderJabbar\LaravelSolr\Models;
 
 use Illuminate\Support\Facades\Http;
 

--- a/src/Schema/SolrSchemaBuilder.php
+++ b/src/Schema/SolrSchemaBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Schema;
+namespace HaiderJabbar\LaravelSolr\Schema;
 
 class SolrSchemaBuilder
 {

--- a/src/Services/CoreSolrService.php
+++ b/src/Services/CoreSolrService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Services;
+namespace HaiderJabbar\LaravelSolr\Services;
 
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Exception;

--- a/src/Services/FieldsSolrService.php
+++ b/src/Services/FieldsSolrService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Services;
+namespace HaiderJabbar\LaravelSolr\Services;
 
 use Exception;
 use Illuminate\Support\Facades\Http;

--- a/src/Services/SolrQueryBuilder.php
+++ b/src/Services/SolrQueryBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Services;
+namespace HaiderJabbar\LaravelSolr\Services;
 
 use Illuminate\Support\Facades\Http;
 

--- a/src/SolrServiceProvider.php
+++ b/src/SolrServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace haiderjabbar\laravelsolr;
+namespace HaiderJabbar\LaravelSolr;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/tests/Unit/Console/Commands/CreateSolrCoreTest.php
+++ b/tests/Unit/Console/Commands/CreateSolrCoreTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Console\Commands;
 
-use haiderjabbar\laravelsolr\Console\Commands\CreateSolrCore;
+use HaiderJabbar\LaravelSolr\Console\Commands\CreateSolrCore;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;

--- a/tests/Unit/Console/Commands/CreateSolrFieldsTest.php
+++ b/tests/Unit/Console/Commands/CreateSolrFieldsTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Console\Commands;
 
-use haiderjabbar\laravelsolr\Console\Commands\CreateSolrFields;
-use haiderjabbar\laravelsolr\Schema\SolrSchemaBuilder;
+use HaiderJabbar\LaravelSolr\Console\Commands\CreateSolrFields;
+use HaiderJabbar\LaravelSolr\Schema\SolrSchemaBuilder;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 use Mockery;

--- a/tests/Unit/Console/Commands/DeleteSolrCoreTest.php
+++ b/tests/Unit/Console/Commands/DeleteSolrCoreTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Console\Commands;
 
-use haiderjabbar\laravelsolr\Console\Commands\DeleteSolrCore;
+use HaiderJabbar\LaravelSolr\Console\Commands\DeleteSolrCore;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Console\Application;
@@ -41,7 +41,7 @@ class DeleteSolrCoreTest extends TestCase
         $stub = $this->command->getMigrationStub($coreName);
 
         $this->assertStringContainsString('use Illuminate\\Database\\Migrations\\Migration;', $stub);
-        $this->assertStringContainsString('use haiderjabbar\\laravelsolr\\Services\\CoreSolrService;', $stub);
+        $this->assertStringContainsString('use HaiderJabbar\\LaravelSolr\\Services\\CoreSolrService;', $stub);
         $this->assertStringContainsString('public function up()', $stub);
         $this->assertStringContainsString('public function down()', $stub);
         $this->assertStringContainsString("\$this->coreSolrService->deleteCore('{$coreName}');", $stub);

--- a/tests/Unit/Console/Commands/DeleteSolrFieldsTest.php
+++ b/tests/Unit/Console/Commands/DeleteSolrFieldsTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Console\Commands;
 
-use haiderjabbar\laravelsolr\Console\Commands\DeleteSolrFields;
+use HaiderJabbar\LaravelSolr\Console\Commands\DeleteSolrFields;
 use Illuminate\Support\Facades\File;
 use Mockery;
 use Tests\TestCase;
@@ -28,7 +28,7 @@ class DeleteSolrFieldsTest extends TestCase
             ->with(Mockery::type('string'), Mockery::type('string'));
 
         // Mock the FieldsSolrService that will be used in the migration stub
-        $fieldsSolrServiceMock = Mockery::mock('overload:haiderjabbar\laravelsolr\Services\FieldsSolrService');
+        $fieldsSolrServiceMock = Mockery::mock('overload:HaiderJabbar\LaravelSolr\Services\FieldsSolrService');
         $fieldsSolrServiceMock->shouldReceive('deleteFieldsFromCore')
             ->once()
             ->with('testCore', ['title', 'author']);
@@ -52,7 +52,7 @@ class DeleteSolrFieldsTest extends TestCase
             ->with(Mockery::type('string'), Mockery::type('string'));
 
         // Mock the FieldsSolrService but expect no calls since no fields are being deleted
-        $fieldsSolrServiceMock = Mockery::mock('overload:haiderjabbar\laravelsolr\Services\FieldsSolrService');
+        $fieldsSolrServiceMock = Mockery::mock('overload:HaiderJabbar\LaravelSolr\Services\FieldsSolrService');
         $fieldsSolrServiceMock->shouldReceive('deleteFieldsFromCore')
             ->never();
 

--- a/tests/Unit/Console/Commands/UpdateSolrCoreTest.php
+++ b/tests/Unit/Console/Commands/UpdateSolrCoreTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Console\Commands;
 
-use haiderjabbar\laravelsolr\Console\Commands\UpdateSolrCore;
+use HaiderJabbar\LaravelSolr\Console\Commands\UpdateSolrCore;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Console\Application;
@@ -44,7 +44,7 @@ class UpdateSolrCoreTest extends TestCase
         $stub = $this->command->getMigrationStub($oldCoreName, $newCoreName);
 
         $this->assertStringContainsString('use Illuminate\\Database\\Migrations\\Migration;', $stub);
-        $this->assertStringContainsString('use haiderjabbar\\laravelsolr\\Services\\CoreSolrService;', $stub);
+        $this->assertStringContainsString('use HaiderJabbar\\LaravelSolr\\Services\\CoreSolrService;', $stub);
         $this->assertStringContainsString('public function up()', $stub);
         $this->assertStringContainsString('public function down()', $stub);
         $this->assertStringContainsString("\$this->coreSolrService->updateCore('{$oldCoreName}', '{$newCoreName}');", $stub);

--- a/tests/Unit/Console/Commands/UpdateSolrFieldsTest.php
+++ b/tests/Unit/Console/Commands/UpdateSolrFieldsTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Console\Commands;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Console\Commands;
 
-use haiderjabbar\laravelsolr\Console\Commands\UpdateSolrFields;
-use haiderjabbar\laravelsolr\Schema\SolrSchemaBuilder;
+use HaiderJabbar\LaravelSolr\Console\Commands\UpdateSolrFields;
+use HaiderJabbar\LaravelSolr\Schema\SolrSchemaBuilder;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 use Mockery;

--- a/tests/Unit/Models/SolrModelTest.php
+++ b/tests/Unit/Models/SolrModelTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Models;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Models;
 
 
 use Tests\TestCase;
 
 // This imports Laravel's TestCase
 use Illuminate\Support\Facades\Http;
-use haiderjabbar\laravelsolr\Models\SolrModel;
+use HaiderJabbar\LaravelSolr\Models\SolrModel;
 
 class SolrModelTest extends TestCase
 {

--- a/tests/Unit/Services/CoreSolrServiceTest.php
+++ b/tests/Unit/Services/CoreSolrServiceTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Services;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Services;
 
 use Exception;
-use haiderjabbar\laravelsolr\Services\CoreSolrService;
+use HaiderJabbar\LaravelSolr\Services\CoreSolrService;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\ConsoleOutput;

--- a/tests/Unit/Services/FieldsSolrServiceTest.php
+++ b/tests/Unit/Services/FieldsSolrServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit;
 
-use haiderjabbar\laravelsolr\Services\FieldsSolrService;
+use HaiderJabbar\LaravelSolr\Services\FieldsSolrService;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Tests\TestCase;
 

--- a/tests/Unit/Services/SolrQueryBuilderTest.php
+++ b/tests/Unit/Services/SolrQueryBuilderTest.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace haiderjabbar\laravelsolr\Tests\Unit\Services;
+namespace HaiderJabbar\LaravelSolr\Tests\Unit\Services;
 
-use haiderjabbar\laravelsolr\Services\SolrQueryBuilder;
+use HaiderJabbar\LaravelSolr\Services\SolrQueryBuilder;
 use Illuminate\Support\Facades\Http;
 
 // Import Http facade correctly


### PR DESCRIPTION
This PR introduce a refactoring of namespace as per the PSR standard. A fully-qualified namespace and class must have the following structure `\<Vendor Name>\(<Namespace>\)*<Class Name>` 

PSR Link: [https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md)

![image](https://github.com/user-attachments/assets/1de36f2d-7999-4791-852c-f05bad64d797)
